### PR TITLE
Document data for variable key

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -645,6 +645,10 @@ declare module "node-appwrite" {
           */
           $collection: string;
           /**
+          *  Collection data
+          */
+          [key: string]: any; // Document data for variable key ,
+          /**
           * Document creation date in Unix timestamp.
           */
           $createdAt: number;


### PR DESCRIPTION
Document data for variable key

When I try to get data from documentation, vscode prompts "Property 'id' does not exist on type 'Document'.ts(2339)",
![image](https://user-images.githubusercontent.com/11499264/186119251-a8e92376-8ab4-4e86-8fd2-6c280d4012a6.png)

I referenced the contents of this blog，the URL is
https://bobbyhadz.com/blog/typescript-property-does-not-exist-on-type#:~:text=The%20%22Property%20does%20not%20exist,type%20with%20variable%20key%20names.

I found that the returned data style is
![image](https://user-images.githubusercontent.com/11499264/186119993-85b964ca-b587-4f16-bb94-74b5de03af30.png)

so I change "type Document" define , 
add code :
[key: string]: any; // Document data for variable key 

