### PR TITLE
Add type for main function

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3837,4 +3837,20 @@ declare module "node-appwrite" {
      */
     updatePhoneVerification<Preferences extends Models.Preferences>(userId: string, phoneVerification: boolean): Promise<Models.User<Preferences>>;
   }
+
+  export interface FunctionRequest {
+    payload: string
+    headers: { [name: string]: string }
+    variables: { [name: string]: string }
+  }
+
+  export interface FunctionResponse {
+    send: (text: string, status?: number) => void
+    json: (body: object, status?: number) => void
+  }
+
+  /**
+   * Type for "main" function
+   */
+  export type AppwriteFunction = (req: FunctionRequest, res: FunctionResponse) => void
 }


### PR DESCRIPTION
## What does this PR do?

Adds type for main function

## Example

```
import { AppwriteFunction } from 'node-appwrite'

const main: AppwriteFunction = async (req, res) => {
    const client = new Client()
    client.setEndpoint(req.variables['APPWRITE_ENDPOINT'])
    client.setProject(req.variables['APPWRITE_FUNCTION_PROJECT_ID'])
    client.setKey(req.variables['APPWRITE_API_KEY'])

    return res.send('Foo')
}
```