### PR TITLE
Check if the bucketId/fileId is empty ('') then throw exception

### DIFF
--- a/lib/services/storage.js
+++ b/lib/services/storage.js
@@ -519,11 +519,11 @@ class Storage extends Service {
     async deleteFile(bucketId, fileId) {
         let path = '/storage/buckets/{bucketId}/files/{fileId}'.replace('{bucketId}', bucketId).replace('{fileId}', fileId);
         let payload = {};
-        if (typeof bucketId === 'undefined') {
+        if (typeof bucketId === 'undefined' || bucketId === '') {
             throw new AppwriteException('Missing required parameter: "bucketId"');
         }
 
-        if (typeof fileId === 'undefined') {
+        if (typeof fileId === 'undefined' || fileId === '') {
             throw new AppwriteException('Missing required parameter: "fileId"');
         }
 


### PR DESCRIPTION
## What does this PR do?

Enables to throw an exception on `deleteFile(bucketId,fileId)` if bucketId or fileId are empty string: `bucketId === '' ` `fileId === ''` 

## Related PRs and Issues

A user raised the missing exception on an empty string as an [issue](https://github.com/appwrite/appwrite/issues/5310) (in the main appwrite repository)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes