### PR TITLE
fix: add the type property to the AppwriteException declaration

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2488,6 +2488,7 @@ declare module "node-appwrite" {
   export class AppwriteException extends Error {
     public code: number | null;
     public response: string | null;
+    public type: string | null;
     constructor(message: string, code?: number, response?: string);
   }
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

This PR add the missing type property to the AppwriteException declaration

## Test Plan

No test plan, it's only declaration

## Related PRs and Issues

https://github.com/appwrite/sdk-for-node/issues/73

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes