### PR TITLE
chore: bump SDK version to 25.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "node-appwrite",
-  "version": "25.1.0",
+  "version": "25.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "node-appwrite",
-      "version": "25.1.0",
+      "version": "25.2.0",
       "dependencies": {
         "json-bigint": "1.0.0",
         "node-fetch-native-with-agent": "1.7.2"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "node-appwrite",
   "homepage": "https://appwrite.io/support",
   "description": "Appwrite is an open-source self-hosted backend server that abstracts and simplifies complex and repetitive development tasks behind a very simple REST API",
-  "version": "25.1.0",
+  "version": "25.2.0",
   "license": "BSD-3-Clause",
   "main": "dist/index.js",
   "type": "commonjs",

--- a/src/client.ts
+++ b/src/client.ts
@@ -74,7 +74,7 @@ class AppwriteException extends Error {
 }
 
 function getUserAgent() {
-    let ua = 'AppwriteNodeJSSDK/25.1.0';
+    let ua = 'AppwriteNodeJSSDK/25.2.0';
 
     // `process` is a global in Node.js, but not fully available in all runtimes.
     const platform: string[] = [];
@@ -128,7 +128,7 @@ class Client {
         'x-sdk-name': 'Node.js',
         'x-sdk-platform': 'server',
         'x-sdk-language': 'nodejs',
-        'x-sdk-version': '25.1.0',
+        'x-sdk-version': '25.2.0',
         'user-agent' : getUserAgent(),
         'X-Appwrite-Response-Format': '1.9.5',
     };


### PR DESCRIPTION
This PR bumps SDK version metadata to 25.2.0 after the concurrent chunk upload update.